### PR TITLE
feat(views): Add SettingsView to save level & nickname

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,13 +3,26 @@ import { Routes, Route } from 'react-router-dom';
 import { useState } from 'react';
 import BattleshipView from './views/BattleshipView';
 import SettingsView from './views/SettingsView';
+import { levels } from './util';
 
 function App() {
-  const [gameLevel] = useState('easy');
+  const [gameLevel, setGameLevel] = useState('easy');
+  const [customChances, setCustomChances] = useState(undefined);
+  const chancesByLevel = levels.find((level) => level.id === gameLevel).chances;
   return (
     <Routes>
-      <Route path="/" element={<BattleshipView level={gameLevel} exact />} />
-      <Route path="/settings" element={<SettingsView />} exact />
+      <Route path="/" element={<BattleshipView initialChances={customChances || chancesByLevel} exact />} />
+      <Route
+        path="/settings"
+        element={(
+          <SettingsView
+            levelSelected={gameLevel}
+            saveLevel={setGameLevel}
+            saveCustomChances={setCustomChances}
+          />
+        )}
+        exact
+      />
     </Routes>
   );
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -27,6 +27,7 @@ function App() {
           element={(
             <SettingsView
               levelSelected={gameLevel}
+              chances={customChances || chancesByLevel}
               saveLevel={setGameLevel}
               saveCustomChances={setCustomChances}
             />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,29 +1,40 @@
 import './App.css';
 import { Routes, Route } from 'react-router-dom';
 import { useState } from 'react';
+import styled from 'styled-components';
 import BattleshipView from './views/BattleshipView';
 import SettingsView from './views/SettingsView';
 import { levels } from './util';
+
+const Container = styled.div`
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  justify-content: center;
+`;
 
 function App() {
   const [gameLevel, setGameLevel] = useState('easy');
   const [customChances, setCustomChances] = useState(undefined);
   const chancesByLevel = levels.find((level) => level.id === gameLevel).chances;
   return (
-    <Routes>
-      <Route path="/" element={<BattleshipView initialChances={customChances || chancesByLevel} exact />} />
-      <Route
-        path="/settings"
-        element={(
-          <SettingsView
-            levelSelected={gameLevel}
-            saveLevel={setGameLevel}
-            saveCustomChances={setCustomChances}
-          />
+    <Container>
+      <Routes>
+        <Route path="/" element={<BattleshipView initialChances={customChances || chancesByLevel} exact />} />
+        <Route
+          path="/settings"
+          element={(
+            <SettingsView
+              levelSelected={gameLevel}
+              saveLevel={setGameLevel}
+              saveCustomChances={setCustomChances}
+            />
         )}
-        exact
-      />
-    </Routes>
+          exact
+        />
+      </Routes>
+    </Container>
   );
 }
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,12 +2,14 @@ import './App.css';
 import { Routes, Route } from 'react-router-dom';
 import { useState } from 'react';
 import BattleshipView from './views/BattleshipView';
+import SettingsView from './views/SettingsView';
 
 function App() {
   const [gameLevel] = useState('easy');
   return (
     <Routes>
-      <Route path="/" element={<BattleshipView level={gameLevel} />} />
+      <Route path="/" element={<BattleshipView level={gameLevel} exact />} />
+      <Route path="/settings" element={<SettingsView />} exact />
     </Routes>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,20 @@
+@import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap');
+
 body {
   margin: 0;
-  font-family: 'Roboto', sans-serif;
+  font-family: 'Press Start 2P', cursive;
   background-color: #181A1B;
+  color: #ffffff;
+}
+
+/* Chrome, Safari, Edge, Opera */
+input::-webkit-outer-spin-button,
+input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+/* Firefox */
+input[type=number] {
+  -moz-appearance: textfield;
 }

--- a/src/util.js
+++ b/src/util.js
@@ -1,8 +1,9 @@
-export const chancesByLevel = {
-  easy: null, // here null is equal to infinity chances
-  medium: 100,
-  hard: 50,
-};
+export const levels = [
+  { id: 'easy', name: 'easy', chances: null }, // here null is equal to infinity chances
+  { id: 'medium', name: 'medium', chances: 100 },
+  { id: 'hard', name: 'hard', chances: 50 },
+  { id: 'custom', name: 'choose my chances', chances: undefined },
+];
 
 export const squaresColor = {
   battleship: '#952226',

--- a/src/views/BattleshipView.jsx
+++ b/src/views/BattleshipView.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
 import { useState } from 'react';
 import Table from '../components/TableGame';
 import GameChancesDisplay from '../components/GameChancesDisplay';
@@ -9,14 +8,6 @@ import {
   checkIfShipIsDestroyed,
   resgisterAShotAndGetShipPositions,
 } from '../controllers/shots';
-
-const Container = styled.div`
-  align-items: center;
-  display: flex;
-  flex-direction: column;
-  height: 100vh;
-  justify-content: center;
-`;
 
 const BattleshipView = ({ initialChances }) => {
   const [squares, setSquares] = useState(buildInitialTable());
@@ -37,7 +28,7 @@ const BattleshipView = ({ initialChances }) => {
     }
   };
   return (
-    <Container>
+    <>
       <GameChancesDisplay chances={gameChances} />
       <Table>
         {squares.map(
@@ -51,7 +42,7 @@ const BattleshipView = ({ initialChances }) => {
           ),
         )}
       </Table>
-    </Container>
+    </>
   );
 };
 

--- a/src/views/BattleshipView.jsx
+++ b/src/views/BattleshipView.jsx
@@ -9,7 +9,6 @@ import {
   checkIfShipIsDestroyed,
   resgisterAShotAndGetShipPositions,
 } from '../controllers/shots';
-import { chancesByLevel } from '../util';
 
 const Container = styled.div`
   align-items: center;
@@ -19,9 +18,9 @@ const Container = styled.div`
   justify-content: center;
 `;
 
-const BattleshipView = ({ level }) => {
+const BattleshipView = ({ initialChances }) => {
   const [squares, setSquares] = useState(buildInitialTable());
-  const [gameChances, setGameChances] = useState(chancesByLevel[level]);
+  const [gameChances, setGameChances] = useState(initialChances);
   const chancesController = () => {
     if (gameChances) {
       setGameChances((prevGameChances) => prevGameChances - 1);
@@ -59,5 +58,9 @@ const BattleshipView = ({ level }) => {
 export default BattleshipView;
 
 BattleshipView.propTypes = {
-  level: PropTypes.string.isRequired,
+  initialChances: PropTypes.number,
+};
+
+BattleshipView.defaultProps = {
+  initialChances: 20,
 };

--- a/src/views/SettingsView.jsx
+++ b/src/views/SettingsView.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import styled from 'styled-components';
 
 const Label = styled.label`
@@ -17,25 +18,37 @@ const Field = styled.div`
   margin: 2rem 0;
 `;
 
-const SettingsView = () => (
-  <>
-    <Field>
-      <Label htmlFor="user-nickname">Nickname</Label>
-      <Input type="text" id="user-nickname" placeholder="Jack Sparrow" />
-    </Field>
-    <Field>
-      <Button>easy</Button>
-      <Button>medium</Button>
-      <Button>hard</Button>
-    </Field>
-    <Field>
-      <Label htmlFor="user-chances">Choose my game chances</Label>
-      <Input type="number" id="user-chances" placeholder="20" min="20" />
-    </Field>
-    <Button type="submit">
-      start game
-    </Button>
-  </>
-);
+const SettingsView = () => {
+  const [nickname, setNickname] = useState('');
+  const handleInput = (event) => {
+    const value = event.target.value.trim();
+    setNickname(value);
+  };
+  return (
+    <>
+      <Field>
+        <Label htmlFor="user-nickname">Nickname</Label>
+        <Input
+          type="text"
+          id="user-nickname"
+          placeholder="Jack Sparrow"
+          onInput={handleInput}
+        />
+      </Field>
+      <Field>
+        <Button>easy</Button>
+        <Button>medium</Button>
+        <Button>hard</Button>
+      </Field>
+      <Field>
+        <Label htmlFor="user-chances">Choose my game chances</Label>
+        <Input type="number" id="user-chances" placeholder="20" min="20" />
+      </Field>
+      <Button type="submit" disabled={!nickname}>
+        start game
+      </Button>
+    </>
+  );
+};
 
 export default SettingsView;

--- a/src/views/SettingsView.jsx
+++ b/src/views/SettingsView.jsx
@@ -47,7 +47,7 @@ const Field = styled.div`
   margin: 2rem 0;
 `;
 
-const SettingsView = ({ levelSelected, saveLevel }) => {
+const SettingsView = ({ levelSelected, saveLevel, chances }) => {
   const navigate = useNavigate();
   const [nickname, setNickname] = useState('');
   const handleInput = (event) => {
@@ -63,7 +63,7 @@ const SettingsView = ({ levelSelected, saveLevel }) => {
   return (
     <>
       <Field>
-        <Label htmlFor="user-nickname">Nickname</Label>
+        <Label htmlFor="user-nickname">Nickname:</Label>
         <Input
           type="text"
           id="user-nickname"
@@ -84,7 +84,14 @@ const SettingsView = ({ levelSelected, saveLevel }) => {
       </Field>
       <Field>
         <Label htmlFor="user-chances">
-          <Input type="number" id="user-chances" placeholder="20" min="20" readOnly={levelSelected !== 'custom'} />
+          Chances:
+          <Input
+            type={levelSelected === 'easy' ? 'text' : 'number'}
+            id="user-chances"
+            min="20"
+            value={chances || 'Infinity'}
+            readOnly={levelSelected !== 'custom'}
+          />
         </Label>
       </Field>
       <ButtonSuccess
@@ -100,7 +107,12 @@ const SettingsView = ({ levelSelected, saveLevel }) => {
 
 export default SettingsView;
 
+SettingsView.defaultProps = {
+  chances: 20,
+};
+
 SettingsView.propTypes = {
   levelSelected: PropTypes.string.isRequired,
   saveLevel: PropTypes.func.isRequired,
+  chances: PropTypes.number,
 };

--- a/src/views/SettingsView.jsx
+++ b/src/views/SettingsView.jsx
@@ -1,6 +1,8 @@
+import PropTypes from 'prop-types';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
+import { levels } from '../util';
 
 const Label = styled.label`
   font-size: 2rem;
@@ -19,10 +21,9 @@ const Field = styled.div`
   margin: 2rem 0;
 `;
 
-const SettingsView = () => {
+const SettingsView = ({ levelSelected, saveLevel }) => {
   const navigate = useNavigate();
   const [nickname, setNickname] = useState('');
-
   const handleInput = (event) => {
     const value = event.target.value.trim();
     setNickname(value);
@@ -45,9 +46,15 @@ const SettingsView = () => {
         />
       </Field>
       <Field>
-        <Button>easy</Button>
-        <Button>medium</Button>
-        <Button>hard</Button>
+        {levels.map((level) => (
+          <Button
+            key={level.id}
+            selected={levelSelected === level.id}
+            onClick={() => saveLevel(level.id)}
+          >
+            {level.name}
+          </Button>
+        ))}
       </Field>
       <Field>
         <Label htmlFor="user-chances">Choose my game chances</Label>
@@ -65,3 +72,8 @@ const SettingsView = () => {
 };
 
 export default SettingsView;
+
+SettingsView.propTypes = {
+  levelSelected: PropTypes.string.isRequired,
+  saveLevel: PropTypes.func.isRequired,
+};

--- a/src/views/SettingsView.jsx
+++ b/src/views/SettingsView.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 const Label = styled.label`
@@ -19,11 +20,19 @@ const Field = styled.div`
 `;
 
 const SettingsView = () => {
+  const navigate = useNavigate();
   const [nickname, setNickname] = useState('');
+
   const handleInput = (event) => {
     const value = event.target.value.trim();
     setNickname(value);
   };
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    navigate('/');
+  };
+
   return (
     <>
       <Field>
@@ -44,7 +53,11 @@ const SettingsView = () => {
         <Label htmlFor="user-chances">Choose my game chances</Label>
         <Input type="number" id="user-chances" placeholder="20" min="20" />
       </Field>
-      <Button type="submit" disabled={!nickname}>
+      <Button
+        type="submit"
+        disabled={!nickname}
+        onClick={handleSubmit}
+      >
         start game
       </Button>
     </>

--- a/src/views/SettingsView.jsx
+++ b/src/views/SettingsView.jsx
@@ -5,16 +5,42 @@ import styled from 'styled-components';
 import { levels } from '../util';
 
 const Label = styled.label`
+  color: #05FC32;
   font-size: 2rem;
+  margin: 0 0.75rem;
 `;
 
 const Input = styled.input`
+  background: transparent;
+  color: ${(props) => (props.readOnly ? '#ffffffa2' : '#ffffff')};
+  font-size: 1.5rem;
+  font-family: 'Press Start 2P', cursive;
+  margin: 0 0.75rem;
+  padding: 0.5rem 1rem;
   outline: 0;
 `;
 
 const Button = styled.button`
   cursor: pointer;
+  font-size: 1.5rem;
+  font-family: 'Press Start 2P', cursive;
+  margin: 0.75rem;
+  padding: 0.5rem 1rem;
   text-transform: uppercase;
+`;
+
+const ButtonSuccess = styled(Button)`
+  background-color: #113CFC;
+  color: #ffffff;
+  :disabled {
+    background-color: transparent;
+    color: #ffffffa2;
+  }
+`;
+
+const ButtonLevel = styled(Button)`
+  background-color: ${(props) => (props.selected ? '#FCC82B' : 'transparent')};
+  color: ${(props) => (props.selected ? '#000000' : '#ffffffa2')};
 `;
 
 const Field = styled.div`
@@ -47,26 +73,27 @@ const SettingsView = ({ levelSelected, saveLevel }) => {
       </Field>
       <Field>
         {levels.map((level) => (
-          <Button
+          <ButtonLevel
             key={level.id}
             selected={levelSelected === level.id}
             onClick={() => saveLevel(level.id)}
           >
             {level.name}
-          </Button>
+          </ButtonLevel>
         ))}
       </Field>
       <Field>
-        <Label htmlFor="user-chances">Choose my game chances</Label>
-        <Input type="number" id="user-chances" placeholder="20" min="20" />
+        <Label htmlFor="user-chances">
+          <Input type="number" id="user-chances" placeholder="20" min="20" readOnly={levelSelected !== 'custom'} />
+        </Label>
       </Field>
-      <Button
+      <ButtonSuccess
         type="submit"
         disabled={!nickname}
         onClick={handleSubmit}
       >
         start game
-      </Button>
+      </ButtonSuccess>
     </>
   );
 };

--- a/src/views/SettingsView.jsx
+++ b/src/views/SettingsView.jsx
@@ -57,6 +57,7 @@ const SettingsView = ({ levelSelected, saveLevel, chances }) => {
 
   const handleSubmit = (event) => {
     event.preventDefault();
+    sessionStorage.setItem('nickname', nickname);
     navigate('/');
   };
 

--- a/src/views/SettingsView.jsx
+++ b/src/views/SettingsView.jsx
@@ -1,0 +1,41 @@
+import styled from 'styled-components';
+
+const Label = styled.label`
+  font-size: 2rem;
+`;
+
+const Input = styled.input`
+  outline: 0;
+`;
+
+const Button = styled.button`
+  cursor: pointer;
+  text-transform: uppercase;
+`;
+
+const Field = styled.div`
+  margin: 2rem 0;
+`;
+
+const SettingsView = () => (
+  <>
+    <Field>
+      <Label htmlFor="user-nickname">Nickname</Label>
+      <Input type="text" id="user-nickname" placeholder="Jack Sparrow" />
+    </Field>
+    <Field>
+      <Button>easy</Button>
+      <Button>medium</Button>
+      <Button>hard</Button>
+    </Field>
+    <Field>
+      <Label htmlFor="user-chances">Choose my game chances</Label>
+      <Input type="number" id="user-chances" placeholder="20" min="20" />
+    </Field>
+    <Button type="submit">
+      start game
+    </Button>
+  </>
+);
+
+export default SettingsView;


### PR DESCRIPTION
- It adds settings view in `/settings` route.
- It shows 4 buttons to select the game level.
- It saves user nickname in session storage.
- It shows predefined chances.
- It adds button /**start game**) to change to next view.

![settings-view](https://user-images.githubusercontent.com/32286663/141659701-82e3309f-6d2c-4a5f-a17b-4933c82730da.png)

This PR closes #18 
